### PR TITLE
eltpatch.in: support slibtoolize

### DIFF
--- a/eltpatch.in
+++ b/eltpatch.in
@@ -217,7 +217,7 @@ elibtoolize() {
 		fi
 
 		# patching ltmain.sh
-		[[ -f ${d}/ltmain.sh ]] &&
+		[[ -f ${d}/ltmain.sh ]] && sed -n '1p' ${d}/ltmain.sh | grep -qsv '/dev/null' &&
 		for p in ${elt_patches} ; do
 			ret=0
 


### PR DESCRIPTION
Patcheing `ltmain.sh` is not applicable when `LIBTOOLIZE=slibtoolize` which copies an `ltmain.sh` script with `/dev/null` in the shebang.

Gentoo issue: https://bugs.gentoo.org/927823

To test slibtoolize inside of an ebuild.

1. Install slibtool-9999.
2. In make.conf:
```
AT_M4DIR='/usr/share/slibtool'
LIBTOOLIZE='slibtoolize'
```
3. Build any ebuild that uses `eautoreconf`.
